### PR TITLE
Allow it to be used with any version of geojsonhint that the user has installed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "bugs": {
     "url": "https://github.com/calvinmetcalf/geojson-assert/issues"
   },
-  "dependencies": {
-    "geojsonhint": "~0.1.5"
+  "peerDependencies": {
+    "geojsonhint": "*"
   },
   "devDependencies": {
     "mocha": "~1.13.0"


### PR DESCRIPTION
Allow it to be used with any version of geojsonhint that the user has installed.